### PR TITLE
Fix Cam playback with voctomix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,19 @@ Python's help output is split.
 `./vplay -h` shows the available commands and `./vplay $command -h` shows the help for the individual command.
 
 The player volume can be changed with the "9" and "0" keys in both ffplay (normal output) and mpv (loudness monitor output).
+
+## Examples
+Play SRT stream with 3 audio tracks, show EBUR graphs and listen to native audio:
+```
+vplay -a 3 -s "ingest.c3voc.de:1337?streamid=play/teststream" srt -l -t 0
+```
+
+Play transcoded stream with 3 audio tracks, show EBUR graphs and listen to translation 1:
+```
+vplay -a 3 -s teststream stream hls-hd -l -t 1
+```
+
+Play RTMP stream with simple stereo audio channel:
+```
+vplay -s ingest2.c3voc.de/relay/test rtmp
+```

--- a/vplay
+++ b/vplay
@@ -421,10 +421,11 @@ def main():
         print("ERROR: Unknown audio track configuration, exiting")
         sys.exit(-1)
 
-    if args.track >= args.num_audio:
-        print("ERROR: Audio track {} is out of range".format(args.track))
-        print("use '-a' parameter to configure more tracks")
-        sys.exit(-1)
+    if hasattr(args, 'type') and not args.type.startswith('cam'):
+        if args.track >= args.num_audio:
+            print("ERROR: Audio track {} is out of range".format(args.track))
+            print("use '-a' parameter to configure more tracks")
+            sys.exit(-1)
 
     # Run chosen functionality
     args.func(args)


### PR DESCRIPTION
Input validation was trying to validate something, which didn't exist. Tested with encoder 1 at GPN20.